### PR TITLE
Release v0.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ My personal .dotfiles and powershell scripts.
 
 ## Pre-requisites
 
-`py-profile` requires at least powershell version 5.0 and the [chocolatey](https://chocolatey.org/) client.
+`py-profile` requires at least [powershell](https://msdn.microsoft.com/en-us/powershell) version 5.0 and the [chocolatey](https://chocolatey.org/) client.
 
 ## Installation
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # py-profile build
 
-version: 0.0.{build}
+version: 0.1.{build}
 platform: x64
 
 environment:


### PR DESCRIPTION
Currently an uninstaller is not needed. Removing the profile loader seems
to be too dangerous. The powershell module may be removed through the
standard module manager.

Resolve #61